### PR TITLE
Restore ParameterConfiguration.cs (accidentally corrupted by bot PR #92)

### DIFF
--- a/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerConfigurations/ParameterConfiguration.cs
+++ b/FHIR/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerConfigurations/ParameterConfiguration.cs
@@ -1,1 +1,42 @@
-already applied — double /// <summary> tag on s_validAesKeySizeBits fixed
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Health.Fhir.Anonymizer.Core.AnonymizerConfigurations
+{
+    [DataContract]
+    public class ParameterConfiguration
+    {
+        [DataMember(Name = "dateShiftKey")]
+        public string DateShiftKey { get; set; }
+
+        [DataMember(Name = "dateShiftScope")]
+        public DateShiftScope DateShiftScope { get; set; }
+
+        [DataMember(Name = "dateShiftFixedOffsetInDays")]
+        public int? DateShiftFixedOffsetInDays { get; set; }
+
+        [DataMember(Name = "cryptoHashKey")]
+        public string CryptoHashKey { get; set; }
+
+        [DataMember(Name = "encryptKey")]
+        public string EncryptKey { get; set; }
+
+        [DataMember(Name = "enablePartialAgesForRedact")]
+        public bool EnablePartialAgesForRedact { get; set; }
+
+        [DataMember(Name = "enablePartialDatesForRedact")]
+        public bool EnablePartialDatesForRedact { get; set; }
+
+        [DataMember(Name = "enablePartialZipCodesForRedact")]
+        public bool EnablePartialZipCodesForRedact { get; set; }
+
+        [DataMember(Name = "restrictedZipCodeTabulationAreas")]
+        public List<string> RestrictedZipCodeTabulationAreas { get; set; }
+
+        [DataMember(Name = "customSettings")]
+        public JObject CustomSettings { get; set; }
+
+        public string DateShiftKeyPrefix { get; set; }
+    }
+}


### PR DESCRIPTION
I sincerely apologize for the damage caused.

My automated AI bot accidentally submitted PR #92 with corrupted content for `ParameterConfiguration.cs`, replacing the entire file with a debug string instead of making the intended targeted fix. That PR was auto-merged, leaving the file corrupted on master.

This PR restores the file to its original content (matching the Microsoft upstream repo at SHA `acd994c49bb0fc8b4889d80bb484be9fde112c1d`).

The bot has been stopped. I am fixing the underlying safeguards to prevent recurrence.

---
**What was wrong:** File contained only `already applied - double /// <summary> tag on s_validAesKeySizeBits fixed` (75 bytes) instead of the real C# class.

**What this restores:** The complete `ParameterConfiguration` class as it existed before PR #92.